### PR TITLE
feat: Add API endpoint and Python CLI for kudo card creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,136 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+.pdm.toml
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/.kudo-cards.ini.example
+++ b/.kudo-cards.ini.example
@@ -1,0 +1,16 @@
+[api]
+# Your API key (set ENV_KUDO_API_KEY on the server)
+key = 6xhs6crTyO4LKjrO1CEGMUTC1I2giefb
+
+# Base URL of your Kudo Cards application
+url = http://localhost:3000
+
+[defaults]
+# Default sender name (optional)
+from = Your Name
+
+# Default card color (optional, use "random" for random selection)
+card_color = random
+
+# Default card title (optional, use "random" for random selection)
+card_title = random

--- a/CLI-README.md
+++ b/CLI-README.md
@@ -1,0 +1,180 @@
+# Kudo Cards CLI
+
+A command-line tool for sending appreciation cards to team members through the Kudo Cards API.
+
+## Features
+
+- 🎯 **Simple CLI interface** - Send kudo cards with one command
+- 🔧 **Configurable defaults** - Set your preferred sender name, colors, and titles
+- 🎨 **Dynamic options** - Automatically fetches available card styles from API
+- 🔄 **Fallback support** - Works offline with default options
+- 🔑 **Secure authentication** - API key-based authentication
+- 🎲 **Random selection** - Let the tool pick random colors and titles
+
+## Installation
+
+### From PyPI (recommended)
+
+```bash
+pip install kudo-cards-cli
+```
+
+### From source
+
+```bash
+git clone https://github.com/yourusername/kudo-cards.git
+cd kudo-cards
+pip install .
+```
+
+## Configuration
+
+Create a configuration file at `~/.kudo-cards.ini`:
+
+```ini
+[api]
+# Your API key (get this from your Kudo Cards server admin)
+key = your_api_key_here
+
+# Base URL of your Kudo Cards application
+url = http://localhost:3000
+
+[defaults]
+# Default sender name (optional)
+from = Your Name
+
+# Default card color (optional, use "random" for random selection)
+card_color = random
+
+# Default card title (optional, use "random" for random selection)
+card_title = random
+```
+
+## Usage
+
+### Basic usage
+
+```bash
+# Send a kudo card with random color and title
+kudo "John Doe" "Great work on the project!"
+
+# Send with specific options
+kudo "Jane Smith" "Thanks for your help" --from "Mike" -c jonquil -t theBest
+
+# Use random selection explicitly
+kudo "Team" "Amazing presentation!" --from "Manager" -c random -t random
+```
+
+### Advanced usage
+
+```bash
+# Use a custom config file
+kudo "Alice" "Great debugging!" --config /path/to/custom-config.ini
+
+# List available options (fetched from API)
+kudo --list-options
+
+# Get help
+kudo --help
+```
+
+### Command-line options
+
+- `to` - Recipient of the kudo card (required)
+- `for` - Message/reason for the kudo card (required)
+- `--from` - Sender name (optional, uses config default)
+- `-c, --color` - Card color (optional, uses config default or "random")
+- `-t, --title` - Card title (optional, uses config default or "random")
+- `--config` - Path to config file (default: `~/.kudo-cards.ini`)
+- `--list-options` - Show available card titles and colors
+
+## Configuration Priority
+
+The tool uses the following priority order for configuration:
+
+1. **Command-line arguments** (highest priority)
+2. **Config file defaults** (medium priority)
+3. **Built-in defaults** (lowest priority)
+
+## Available Options
+
+### Card Titles
+- `theBest` - "You're the best!"
+- `congrats` - "Congrats!"
+- `greatJob` - "Great job!"
+- `manyThanks` - "Many Thanks!"
+- `amazingWork` - "Amazing Work!"
+- `awesome` - "You're awesome!"
+- `impressive` - "Impressive!"
+- `didIt` - "You did it!"
+
+### Card Colors
+- `jonquil`
+- `giants-orange`
+- `red-pantone`
+- `rebecca-purple`
+- `moon-stone`
+- `rich-black`
+
+*Note: Actual options are fetched from the API at runtime. The above are fallback defaults.*
+
+## Error Handling
+
+The tool provides clear error messages for common issues:
+
+- ❌ **Missing config file** - Instructions for creating one
+- ❌ **Invalid API key** - Check your authentication
+- ❌ **Invalid options** - Lists available colors/titles
+- ⚠️ **API unavailable** - Falls back to default options
+- ✅ **Success** - Shows card ID and view URL
+
+## Examples
+
+```bash
+# Quick kudo with defaults
+kudo "Sarah" "Excellent presentation today!"
+
+# Specific styling
+kudo "Development Team" "Ship it! 🚀" --from "Product Manager" -c jonquil -t amazingWork
+
+# Using config file for different environments
+kudo "Alice" "Bug fix champion" --config ~/.kudo-cards-prod.ini
+
+# See what options are available
+kudo --list-options
+```
+
+## Development
+
+### Setting up development environment
+
+```bash
+git clone https://github.com/yourusername/kudo-cards.git
+cd kudo-cards
+pip install -e .
+```
+
+### Running tests
+
+```bash
+python -m pytest
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests if applicable
+5. Submit a pull request
+
+## License
+
+MIT License - see LICENSE file for details.
+
+## Support
+
+For issues and questions:
+- 🐛 [Report bugs](https://github.com/yourusername/kudo-cards/issues)
+- 📚 [Documentation](https://github.com/yourusername/kudo-cards#readme)
+- 💬 [Discussions](https://github.com/yourusername/kudo-cards/discussions)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CLI-README.md
+include .kudo-cards.ini.example
+include LICENSE
+recursive-include kudo_cards_cli *.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  mongo:
+    image: mongo:latest
+    container_name: kudo-cards-mongo
+    restart: unless-stopped
+    ports:
+      - "27018:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - kudo-cards-network
+
+  app:
+    image: node:18-alpine
+    container_name: kudo-cards-app
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      MONGODB_URL: mongodb://root:password@mongo:27017/kudo-cards?authSource=admin
+      NODE_ENV: development
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh ./docker-entrypoint.sh
+    depends_on:
+      - mongo
+    networks:
+      - kudo-cards-network
+
+volumes:
+  mongo_data:
+
+networks:
+  kudo-cards-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       MONGODB_URL: mongodb://root:password@mongo:27017/kudo-cards?authSource=admin
       NODE_ENV: development
+      ENV_KUDO_API_KEY: 6xhs6crTyO4LKjrO1CEGMUTC1I2giefb
     working_dir: /app
     volumes:
       - .:/app

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Installing dependencies..."
+yarn install
+
+echo "Starting development server..."
+yarn dev

--- a/kudo_cards_cli/__init__.py
+++ b/kudo_cards_cli/__init__.py
@@ -1,0 +1,9 @@
+"""
+Kudo Cards CLI - Command-line client for sending Kudo Cards
+
+A simple and powerful CLI tool for sending appreciation cards to team members.
+"""
+
+__version__ = "1.0.0"
+__author__ = "Kudo Cards Team"
+__email__ = "team@kudocards.com"

--- a/kudo_cards_cli/main.py
+++ b/kudo_cards_cli/main.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Kudo Cards API Client
+
+Send kudo cards via command line interface.
+Configuration stored in ~/.kudo-cards.ini
+
+Usage:
+    kudo <TO> <FOR> --from ME -c jonquil -t theBest
+"""
+
+import argparse
+import configparser
+import json
+import random
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+
+# Default card options (fallback if API is unavailable)
+DEFAULT_CARD_TITLES = [
+    "theBest", "congrats", "greatJob", "manyThanks",
+    "amazingWork", "awesome", "impressive", "didIt"
+]
+
+DEFAULT_CARD_COLORS = [
+    "jonquil", "giants-orange", "red-pantone",
+    "rebecca-purple", "moon-stone", "rich-black"
+]
+
+
+class KudoClient:
+    def __init__(self, config_file: Optional[str] = None):
+        if config_file:
+            self.config_file = Path(config_file)
+        else:
+            self.config_file = Path.home() / ".kudo-cards.ini"
+        self.api_key = None
+        self.base_url = None
+        self.card_titles = DEFAULT_CARD_TITLES
+        self.card_colors = DEFAULT_CARD_COLORS
+        self._load_config()
+        self._fetch_api_config()
+
+    def _load_config(self):
+        """Load configuration from config file"""
+        if not self.config_file.exists():
+            print(f"Error: Configuration file {self.config_file} not found.")
+            print("Please create it with the following format:")
+            print("""
+[api]
+key = your_api_key_here
+url = http://localhost:3000
+
+[defaults]
+from = Your Name
+card_color = random
+card_title = random
+            """)
+            sys.exit(1)
+
+        config = configparser.ConfigParser()
+        config.read(self.config_file)
+
+        try:
+            self.api_key = config.get('api', 'key')
+            self.base_url = config.get('api', 'url', fallback='http://localhost:3000')
+
+            # Load default values
+            self.default_from = config.get('defaults', 'from', fallback=None)
+            self.default_card_color = config.get('defaults', 'card_color', fallback='random')
+            self.default_card_title = config.get('defaults', 'card_title', fallback='random')
+        except (configparser.NoSectionError, configparser.NoOptionError) as e:
+            print(f"Error reading config file: {e}")
+            sys.exit(1)
+
+    def _fetch_api_config(self):
+        """Fetch card titles and colors from the API"""
+        try:
+            response = requests.get(
+                f"{self.base_url}/api/config",
+                timeout=10
+            )
+
+            if response.status_code == 200:
+                config = response.json()
+                self.card_titles = config.get('cardTitles', DEFAULT_CARD_TITLES)
+                self.card_colors = config.get('cardColors', DEFAULT_CARD_COLORS)
+                print(f"✅ Loaded {len(self.card_titles)} card titles and {len(self.card_colors)} colors from API")
+            else:
+                print(f"⚠️  Failed to fetch config from API (status {response.status_code}), using defaults")
+        except requests.exceptions.RequestException:
+            print("⚠️  Could not connect to API for config, using default options")
+
+    def _get_random_choice(self, choices: list, choice_type: str) -> str:
+        """Get a random choice from the given list"""
+        choice = random.choice(choices)
+        print(f"Randomly selected {choice_type}: {choice}")
+        return choice
+
+    def send_kudo(self, to: str, for_msg: str, from_user: Optional[str] = None,
+                  card_color: Optional[str] = None, card_title: Optional[str] = None) -> bool:
+        """Send a kudo card via the API"""
+
+        # Use config defaults if not provided
+        if from_user is None:
+            from_user = self.default_from
+
+        if card_color is None:
+            card_color = self.default_card_color
+
+        if card_title is None:
+            card_title = self.default_card_title
+
+        # Handle random selections
+        if card_color == "random":
+            card_color = self._get_random_choice(self.card_colors, "card color")
+        elif card_color not in self.card_colors:
+            print(f"Error: Invalid card color '{card_color}'. Available colors: {', '.join(self.card_colors)}")
+            return False
+
+        if card_title == "random":
+            card_title = self._get_random_choice(self.card_titles, "card title")
+        elif card_title not in self.card_titles:
+            print(f"Error: Invalid card title '{card_title}'. Available titles: {', '.join(self.card_titles)}")
+            return False
+
+        # Prepare the payload
+        payload = {
+            "cardTitle": card_title,
+            "cardColor": card_color,
+            "to": to,
+            "for": for_msg,
+            "from": from_user or "",
+            "hearts": 0,
+            "created": datetime.now().isoformat()
+        }
+
+        # Make the API request
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/api/kudo-cards",
+                json=payload,
+                headers=headers,
+                timeout=30
+            )
+
+            if response.status_code == 201:
+                result = response.json()
+                print(f"✅ Kudo card sent successfully!")
+                print(f"Card ID: {result.get('_id', 'N/A')}")
+                if result.get('_id'):
+                    print(f"View card: {self.base_url}/kudo-card/{result['_id']}")
+                return True
+            elif response.status_code == 401:
+                print("❌ Error: Unauthorized. Check your API key in ~/.kudo-cards.ini")
+            elif response.status_code == 400:
+                error_data = response.json()
+                print(f"❌ Error: Invalid data - {error_data.get('error', 'Unknown error')}")
+                if 'details' in error_data:
+                    for detail in error_data['details']:
+                        print(f"  - {detail.get('message', detail)}")
+            elif response.status_code == 503:
+                print("❌ Error: API not configured on server")
+            else:
+                print(f"❌ Error: {response.status_code} - {response.text}")
+
+        except requests.exceptions.RequestException as e:
+            print(f"❌ Network error: {e}")
+
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Send kudo cards via command line",
+        epilog=f"""
+Default card titles: {', '.join(DEFAULT_CARD_TITLES)}
+Default card colors: {', '.join(DEFAULT_CARD_COLORS)}
+(Actual options will be fetched from API)
+
+Examples:
+  kudo "John Doe" "Great work on the project!"
+  kudo "Jane Smith" "Thanks for your help" --from "Mike" -c jonquil -t theBest
+  kudo "Team" "Amazing presentation!" --from "Manager" -c random -t random
+  kudo "Alice" "Great debugging!" --config /path/to/custom-config.ini
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument("to", nargs='?', help="Recipient of the kudo card")
+    parser.add_argument("for", nargs='?', help="Message/reason for the kudo card")
+    parser.add_argument("--from", dest="from_user", help="Sender name (optional)")
+    parser.add_argument("-c", "--color", dest="card_color", default="random",
+                        help="Card color (default: random)")
+    parser.add_argument("-t", "--title", dest="card_title", default="random",
+                        help="Card title (default: random)")
+    parser.add_argument("--list-options", action="store_true",
+                        help="List available card titles and colors")
+    parser.add_argument("--config", dest="config_file",
+                        help="Path to config file (default: ~/.kudo-cards.ini)")
+
+    args = parser.parse_args()
+
+    if args.list_options:
+        # Initialize client to fetch options from API
+        client = KudoClient(config_file=args.config_file)
+        print("Available card titles:")
+        for title in client.card_titles:
+            print(f"  - {title}")
+        print("\nAvailable card colors:")
+        for color in client.card_colors:
+            print(f"  - {color}")
+        return
+
+    if not args.to or not getattr(args, 'for'):
+        parser.error("Both 'to' and 'for' arguments are required unless using --list-options")
+
+    client = KudoClient(config_file=args.config_file)
+    # Only pass CLI args if they were explicitly provided (not defaults)
+    from_user = args.from_user if args.from_user else None
+    card_color = args.card_color if args.card_color != "random" else None
+    card_title = args.card_title if args.card_title != "random" else None
+
+    success = client.send_kudo(
+        to=args.to,
+        for_msg=getattr(args, 'for'),
+        from_user=from_user,
+        card_color=card_color,
+        card_title=card_title
+    )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "kudo-cards-cli"
 version = "1.0.0"
 authors = [
-    {name = "Kudo Cards Team", email = "team@kudocards.com"},
+    {name = "Michał Moroz", email = "michalmoroz@gmail.com"},
 ]
 description = "Command-line client for sending Kudo Cards"
 readme = "CLI-README.md"
@@ -33,9 +33,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/kudo-cards"
-"Bug Tracker" = "https://github.com/yourusername/kudo-cards/issues"
-Documentation = "https://github.com/yourusername/kudo-cards#readme"
+Homepage = "https://github.com/TimmyFight/kudo-cards"
+"Bug Tracker" = "https://github.com/TimmyFight/kudo-cards/issues"
+Documentation = "https://github.com/TimmyFight/kudo-cards#readme"
 
 [project.scripts]
 kudo = "kudo_cards_cli.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kudo-cards-cli"
+version = "1.0.0"
+authors = [
+    {name = "Kudo Cards Team", email = "team@kudocards.com"},
+]
+description = "Command-line client for sending Kudo Cards"
+readme = "CLI-README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Communications",
+    "Topic :: Utilities",
+]
+keywords = ["kudo", "cards", "appreciation", "team", "cli"]
+dependencies = [
+    "requests>=2.25.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/yourusername/kudo-cards"
+"Bug Tracker" = "https://github.com/yourusername/kudo-cards/issues"
+Documentation = "https://github.com/yourusername/kudo-cards#readme"
+
+[project.scripts]
+kudo = "kudo_cards_cli.main:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["kudo_cards_cli*"]
+
+[tool.setuptools.package-data]
+kudo_cards_cli = ["*.ini"]

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { cardColors, cardTitles } from "@/constants";
+
+export async function GET() {
+  try {
+    const config = {
+      cardTitles: cardTitles.map(title => title.name),
+      cardColors: cardColors.map(color => color.name),
+    };
+
+    return NextResponse.json(config, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/kudo-cards/route.ts
+++ b/src/app/api/kudo-cards/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createKudoCard } from "@/app/lib/actions/kudoCard.actions";
+import { UserValidation } from "@/app/lib/validations/kudoCard.validations";
+
+export async function POST(request: NextRequest) {
+  try {
+    const apiKey = process.env.ENV_KUDO_API_KEY;
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "API not configured" },
+        { status: 503 }
+      );
+    }
+
+    const authHeader = request.headers.get("authorization");
+    const providedKey = authHeader?.replace("Bearer ", "");
+
+    if (!providedKey || providedKey !== apiKey) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+
+    const validation = UserValidation.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: "Invalid request data", details: validation.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const result = await createKudoCard({ data: validation.data });
+
+    if (typeof result === "object" && "error" in result) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/global.d.ts
+++ b/src/app/global.d.ts
@@ -1,6 +1,6 @@
 interface CardParameters {
   cardTitle: string;
-  cardColor: strign;
+  cardColor: string;
   to: string;
   for: string;
   from: string;

--- a/src/app/lib/actions/kudoCard.actions.ts
+++ b/src/app/lib/actions/kudoCard.actions.ts
@@ -27,7 +27,9 @@ async function sendKudoToSlack({
   message: string;
   id: string;
 }) {
-  await fetch(process.env.SLACK_WEBHOOK_URL!, {
+  if (!process.env.SLACK_WEBHOOK_URL) return;
+
+  await fetch(process.env.SLACK_WEBHOOK_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Add authenticated API endpoint for kudo card creation (`POST /api/kudo-cards`)
- Add configuration endpoint to expose card options (`GET /api/config`) 
- Create pip-installable Python CLI package for sending kudo cards
- Add Docker development environment setup

## API Changes
- **POST /api/kudo-cards**: Create kudo cards with `ENV_KUDO_API_KEY` authentication
- **GET /api/config**: Public endpoint exposing available card titles and colors
- Fix typo in `global.d.ts` (strign → string)

## Python CLI Package
- **Package name**: `kudo-cards-cli`
- **Command**: `kudo` (available after `pip install .`)
- **Features**:
  - Dynamic option fetching from API with fallback to defaults
  - Configuration file support (`~/.kudo-cards.ini`)
  - Configurable defaults for sender, colors, and titles
  - Random selection support
  - Comprehensive error handling

## Usage Examples
```bash
# Install the CLI
pip install .

# Send a kudo card
kudo "John Doe" "Great work on the project!"

# With specific options
kudo "Jane" "Thanks!" --from "Mike" -c jonquil -t theBest

# List available options (fetched from API)
kudo --list-options
```

## Configuration
The CLI uses `~/.kudo-cards.ini`:
```ini
[api]
key = your_api_key_here
url = http://localhost:3000

[defaults]
from = Your Name
card_color = random
card_title = random
```

## Test plan
- [x] API endpoints work with proper authentication
- [x] Python CLI installs and runs correctly
- [x] CLI fetches options from API and falls back to defaults
- [x] Configuration file parsing works
- [x] Random selection works for colors and titles
- [x] Error handling for invalid inputs and network issues
- [x] Package builds successfully (`python -m build`)

🤖 Generated with [Claude Code](https://claude.ai/code)