### PR TITLE
fix: await Slack notification to ensure delivery

### DIFF
--- a/src/app/lib/actions/kudoCard.actions.ts
+++ b/src/app/lib/actions/kudoCard.actions.ts
@@ -70,7 +70,7 @@ export async function createKudoCard({
   try {
     if (data.from === "") data.from = "John Doe: The Unsung Hero";
     const createdKudoCard = await KudoCard.create(data);
-    sendKudoToSlack({
+    await sendKudoToSlack({
       recipient: data.to,
       message: `${data.for}`,
       id: createdKudoCard._id.toString(),


### PR DESCRIPTION
## Summary
- Added `await` to the `sendKudoToSlack()` call in `createKudoCard()` function to ensure Slack webhook completes before returning

## Problem
The `sendKudoToSlack()` function was called without `await`, causing it to be a "fire and forget" operation. This led to:
- Inconsistent Slack notifications, especially when creating kudo cards via the CLI
- The function returning before the webhook HTTP request completed
- Execution context potentially terminating before the Slack notification was sent
- Silent failures with no error reporting

## Solution
Added `await` to ensure the Slack notification completes before the function returns, guaranteeing consistent delivery and proper error handling.

## Test plan
- [ ] Create a kudo card via the CLI and verify Slack notification is received
- [ ] Create a kudo card via the web interface and verify Slack notification is received
- [ ] Verify both methods now consistently send notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)